### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ drupal_settings:
                 database: mydatabase
                 username: user
                 password: secret
-                isolevel: "SET SESSION transaction_isolation=\\'READ-COMMITTED\\'"
+                isolevel: 'SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED'
           config_directories: # Optional, Drupal 8
             sync: path/to/config
           trusted_hosts: # Optional, Drupal 8


### PR DESCRIPTION
This commit includes a fix for the isolevel key. It was changed to 'isolevel: SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED' to use a more standard syntax that closely follows SQL conventions.